### PR TITLE
Port allocation doesn't work well, when containers are created by jes…

### DIFF
--- a/src/port-client.ts
+++ b/src/port-client.ts
@@ -6,8 +6,13 @@ export interface PortClient {
 }
 
 export class RandomPortClient implements PortClient {
+  private preferredRandomPort(min: number, max: number) {
+    // min and max included
+    return Math.floor(Math.random() * (max - min + 1) + min);
+  }
+
   public getPort(): Promise<Port> {
-    return getRandomPort();
+    return getRandomPort({ port: this.preferredRandomPort(10000, 65535) });
   }
 }
 


### PR DESCRIPTION
…t in parallel.

Due to limitations in 'get-port' library, port conflict occurred too often to be ignored (Documented in get-port: "There is a very tiny chance of a race condition if another process starts using the same port number as you in between the time you get the port number and you actually start using it.") .